### PR TITLE
Incorrect key => value for the image.

### DIFF
--- a/src/Providers/Pinterest.php
+++ b/src/Providers/Pinterest.php
@@ -13,7 +13,7 @@ class Pinterest extends ProviderBase implements ProviderInterface
             array(
                 'url',
                 'title' => 'description',
-                'media' => 'image',
+                'image' => 'media',
             )
         );
     }


### PR DESCRIPTION
The key and value pair were the wrong way round. It should be searching for `image` in the data within the `Page` instance, and assigning that to a `media` get param.